### PR TITLE
Editable chunk sizing

### DIFF
--- a/notebooks/10_storage.ipynb
+++ b/notebooks/10_storage.ipynb
@@ -675,10 +675,12 @@
     "# functions \n",
     "\n",
     "def raw_to_datastack(raw_file, rpl_file, output_dir=None, datapath=L.MAXRF_CUBE, verbose=True, \n",
-    "                    flip_horizontal=False, flip_vertical=False): \n",
+    "                    flip_horizontal=False, flip_vertical=False, chunks=\"auto\", rechunk=False): \n",
     "    '''Convert Bruker Macro XRF (.raw) data file `raw_filename` and (.rpl) shape file `rpl_filename`.  \n",
     "    \n",
     "    into a zarr ZipStore datastack file (.datastack).\n",
+    "\n",
+    "    for information about chunk sizing see: dask.array.core.normalize_chunks\n",
     "    ''' \n",
     "\n",
     "    print('Please wait while preparing data conversion...')\n",
@@ -710,11 +712,13 @@
     "    raw_mm = np.memmap(raw_file, dtype=dtype, mode='r', shape=shape)[::v_stride, ::h_stride] \n",
     "\n",
     "    # initializing dask array \n",
-    "    arr = da.from_array(raw_mm) \n",
+    "    arr = da.from_array(raw_mm, chunks=chunks) \n",
     "    arr = arr.astype(np.float32)\n",
     "\n",
+    "    \n",
     "    # divide into regular chunks\n",
-    "    arr = arr.rechunk(balance=True) \n",
+    "    if rechunk:\n",
+    "        arr = arr.rechunk(balance=True)\n",
     "    \n",
     "    # schedule spectral gaussian smoothing computation  \n",
     "    smoothed = gaussian_filter(arr, (0, 0, 7)) \n",
@@ -734,7 +738,7 @@
     "    \n",
     "    # also compute sum and max spectra and append to zipstore \n",
     "    \n",
-    "    y_max, y_sum = max_and_sum_spectra(datastack_file, datapath=L.MAXRF_CUBE)\n",
+    "    y_max, y_sum = max_and_sum_spectra(datastack_file, datapath=L.MAXRF_CUBE, chunks=chunks)\n",
     "    \n",
     "    append(y_max, L.MAXRF_MAXSPECTRUM, datastack_file)\n",
     "    append(y_sum, L.MAXRF_SUMSPECTRUM, datastack_file)\n",
@@ -855,7 +859,7 @@
     "        tree(datastack_file)\n",
     "        \n",
     "\n",
-    "def max_and_sum_spectra(datastack_file, datapath=L.MAXRF_CUBE): \n",
+    "def max_and_sum_spectra(datastack_file, datapath=L.MAXRF_CUBE, chunks=\"auto\"): \n",
     "    '''Compute sum spectrum and max spectrum for 'maxrf' dataset in *datastack_file*. \n",
     "    \n",
     "    Returns: *y_sum*, *y_max*'''\n",
@@ -865,7 +869,7 @@
     "    root = zarr.open_group(store=zs, mode='r')\n",
     "    \n",
     "    # initialize dask array \n",
-    "    arr = da.from_array(root[datapath])\n",
+    "    arr = da.from_array(root[datapath], chunks=chunks)\n",
     "        \n",
     "    # flatten (better avoid)\n",
     "    h, w, d = arr.shape \n",
@@ -1106,6 +1110,13 @@
     "    \n",
     "   "
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -1113,6 +1124,13 @@
    "display_name": "python3",
    "language": "python",
    "name": "python3"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 2,
+    "version_minor": 0
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
To fix the mermory issue error i encountered in version 0.1.31 I added the parameter chunks and rechunk to the function raw_to_datastack. This way you can choose your own chunk sizes by using [dask.array.core.normalize_chunks](https://docs.dask.org/en/latest/generated/dask.array.core.normalize_chunks.html?highlight=normalize_chunks#dask.array.core.normalize_chunks) this way you can specify the amount of chunks or the chunk size itself. For me using "10 MiB as a chunk size worked on 16 GB RAM.

The reason for making rechunk a bool parameter is so it doesn't interfere with the custom chunk sizing it gives. When choosing not to use the chunks parameter you can set rechunk=True to help with the irregular chunk size problem.